### PR TITLE
Feature: Expose gateway keys and event types as constants

### DIFF
--- a/src/attribute_event_types.rs
+++ b/src/attribute_event_types.rs
@@ -1,14 +1,21 @@
-/// The expected value for the [Event Type Key](self::EVENT_TYPE_KEY) that denotes to
-/// [Object Store Gateway](https://github.com/provenance-io/object-store-gateway) that the event
-/// should be processed as an access grant.
 const ACCESS_GRANT_VALUE: &str = "access_grant";
-
-/// The expected value for the [Event Type Key](self::EVENT_TYPE_KEY) that denotes to
-/// [Object Store Gateway](https://github.com/provenance-io/object-store-gateway) that the event
-/// should be processed as an access revocation.
 const ACCESS_REVOKE_VALUE: &str = "access_revoke";
 
 /// A simple struct to contain all gateway expected event type values.
+///
+/// # Parameters
+///
+/// * `access_grant` The expected value for the [Event Type Key](crate::OS_GATEWAY_EVENT_TYPES) that denotes
+/// to [Object Store Gateway](https://github.com/provenance-io/object-store-gateway) that the event
+/// should be processed as an access grant, and that an entry will be made to allow the target address
+/// access to the underlying records contained in the target scope.
+///
+/// * `access_revoke` The expected value for the [Event Type Key](crate::OS_GATEWAY_EVENT_TYPES) that denotes
+/// to [Object Store Gateway](https://github.com/provenance-io/object-store-gateway) that the event
+/// should be processed as an access revocation, and that all entries for the given target address
+/// and scope address combination should be removed.  Note:  If an access grant id is provided, only
+/// a record with that id will be removed.  If no record exists with that id, then this event will
+/// take no action when interpreted by a gateway.
 pub struct OsGatewayEventTypes<'a> {
     pub access_grant: &'a str,
     pub access_revoke: &'a str,
@@ -16,6 +23,20 @@ pub struct OsGatewayEventTypes<'a> {
 
 /// Contains all different attribute values recognized by [Object Store Gateway](https://github.com/provenance-io/object-store-gateway)
 /// when interpreting the `event_type` key.
+///
+/// # Values
+///
+/// * `access_grant` The expected value for the [Event Type Key](crate::OS_GATEWAY_EVENT_TYPES) that denotes
+/// to [Object Store Gateway](https://github.com/provenance-io/object-store-gateway) that the event
+/// should be processed as an access grant, and that an entry will be made to allow the target address
+/// access to the underlying records contained in the target scope.
+///
+/// * `access_revoke` The expected value for the [Event Type Key](crate::OS_GATEWAY_EVENT_TYPES) that denotes
+/// to [Object Store Gateway](https://github.com/provenance-io/object-store-gateway) that the event
+/// should be processed as an access revocation, and that all entries for the given target address
+/// and scope address combination should be removed.  Note:  If an access grant id is provided, only
+/// a record with that id will be removed.  If no record exists with that id, then this event will
+/// take no action when interpreted by a gateway.
 pub const OS_GATEWAY_EVENT_TYPES: OsGatewayEventTypes<'static> = OsGatewayEventTypes {
     access_grant: ACCESS_GRANT_VALUE,
     access_revoke: ACCESS_REVOKE_VALUE,

--- a/src/attribute_event_types.rs
+++ b/src/attribute_event_types.rs
@@ -1,0 +1,22 @@
+/// The expected value for the [Event Type Key](self::EVENT_TYPE_KEY) that denotes to
+/// [Object Store Gateway](https://github.com/provenance-io/object-store-gateway) that the event
+/// should be processed as an access grant.
+const ACCESS_GRANT_VALUE: &str = "access_grant";
+
+/// The expected value for the [Event Type Key](self::EVENT_TYPE_KEY) that denotes to
+/// [Object Store Gateway](https://github.com/provenance-io/object-store-gateway) that the event
+/// should be processed as an access revocation.
+const ACCESS_REVOKE_VALUE: &str = "access_revoke";
+
+/// A simple struct to contain all gateway expected event type values.
+pub struct OsGatewayEventTypes<'a> {
+    pub access_grant: &'a str,
+    pub access_revoke: &'a str,
+}
+
+/// Contains all different attribute values recognized by [Object Store Gateway](https://github.com/provenance-io/object-store-gateway)
+/// when interpreting the `event_type` key.
+pub const OS_GATEWAY_EVENT_TYPES: OsGatewayEventTypes<'static> = OsGatewayEventTypes {
+    access_grant: ACCESS_GRANT_VALUE,
+    access_revoke: ACCESS_REVOKE_VALUE,
+};

--- a/src/attribute_generator.rs
+++ b/src/attribute_generator.rs
@@ -1,7 +1,4 @@
-use crate::attribute_consts::{
-    ACCESS_GRANT_ID_KEY, ACCESS_GRANT_VALUE, ACCESS_REVOKE_VALUE, EVENT_TYPE_KEY,
-    SCOPE_ADDRESS_KEY, TARGET_ACCOUNT_KEY,
-};
+use crate::{OS_GATEWAY_EVENT_TYPES, OS_GATEWAY_KEYS};
 use std::collections::BTreeMap;
 use std::vec::IntoIter;
 
@@ -42,7 +39,7 @@ impl OsGatewayAttributeGenerator {
         target_account_address: S2,
     ) -> Self {
         Self::new()
-            .with_event_type(ACCESS_GRANT_VALUE)
+            .with_event_type(OS_GATEWAY_EVENT_TYPES.access_grant)
             .with_scope_address(scope_address)
             .with_target_account_address(target_account_address)
     }
@@ -69,7 +66,7 @@ impl OsGatewayAttributeGenerator {
         target_account_address: S2,
     ) -> Self {
         Self::new()
-            .with_event_type(ACCESS_REVOKE_VALUE)
+            .with_event_type(OS_GATEWAY_EVENT_TYPES.access_revoke)
             .with_scope_address(scope_address)
             .with_target_account_address(target_account_address)
     }
@@ -87,19 +84,19 @@ impl OsGatewayAttributeGenerator {
     /// and grantee [Provenance Blockchain Account](https://docs.provenance.io/blockchain/basics/accounts) address
     /// combination at once.
     pub fn with_access_grant_id<S: Into<String>>(self, access_grant_id: S) -> Self {
-        self.insert_attribute(ACCESS_GRANT_ID_KEY, access_grant_id)
+        self.insert_attribute(OS_GATEWAY_KEYS.access_grant_id, access_grant_id)
     }
 
     fn with_event_type<S: Into<String>>(self, event_type: S) -> Self {
-        self.insert_attribute(EVENT_TYPE_KEY, event_type)
+        self.insert_attribute(OS_GATEWAY_KEYS.event_type, event_type)
     }
 
     fn with_scope_address<S: Into<String>>(self, scope_address: S) -> Self {
-        self.insert_attribute(SCOPE_ADDRESS_KEY, scope_address)
+        self.insert_attribute(OS_GATEWAY_KEYS.scope_address, scope_address)
     }
 
     fn with_target_account_address<S: Into<String>>(self, target_account_address: S) -> Self {
-        self.insert_attribute(TARGET_ACCOUNT_KEY, target_account_address)
+        self.insert_attribute(OS_GATEWAY_KEYS.target_account, target_account_address)
     }
 
     fn new() -> Self {
@@ -128,11 +125,8 @@ impl IntoIterator for OsGatewayAttributeGenerator {
 
 #[cfg(test)]
 mod tests {
-    use crate::attribute_consts::{
-        ACCESS_GRANT_ID_KEY, ACCESS_GRANT_VALUE, ACCESS_REVOKE_VALUE, EVENT_TYPE_KEY,
-        SCOPE_ADDRESS_KEY, TARGET_ACCOUNT_KEY,
-    };
     use crate::attribute_generator::OsGatewayAttributeGenerator;
+    use crate::{OS_GATEWAY_EVENT_TYPES, OS_GATEWAY_KEYS};
     use cosmwasm_std::Response;
 
     const DEFAULT_SCOPE_ADDRESS: &str = "scope_address";
@@ -152,30 +146,42 @@ mod tests {
     #[test]
     fn test_access_grant_contents() {
         let mut access_grant = OsGatewayAttributeGenerator::test_access_grant();
-        assert_attribute_values_are_correct(ACCESS_GRANT_VALUE, &access_grant, None);
+        assert_attribute_values_are_correct(
+            OS_GATEWAY_EVENT_TYPES.access_grant,
+            &access_grant,
+            None,
+        );
         access_grant = access_grant.with_access_grant_id(DEFAULT_GRANT_ID);
         assert_attribute_values_are_correct(
-            ACCESS_GRANT_VALUE,
+            OS_GATEWAY_EVENT_TYPES.access_grant,
             &access_grant,
             Some(DEFAULT_GRANT_ID),
         );
         access_grant = access_grant.with_access_grant_id("grant_id_2");
-        assert_attribute_values_are_correct(ACCESS_GRANT_VALUE, &access_grant, Some("grant_id_2"));
+        assert_attribute_values_are_correct(
+            OS_GATEWAY_EVENT_TYPES.access_grant,
+            &access_grant,
+            Some("grant_id_2"),
+        );
     }
 
     #[test]
     fn test_access_revoke_contents() {
         let mut access_revoke = OsGatewayAttributeGenerator::test_access_revoke();
-        assert_attribute_values_are_correct(ACCESS_REVOKE_VALUE, &access_revoke, None);
+        assert_attribute_values_are_correct(
+            OS_GATEWAY_EVENT_TYPES.access_revoke,
+            &access_revoke,
+            None,
+        );
         access_revoke = access_revoke.with_access_grant_id(DEFAULT_GRANT_ID);
         assert_attribute_values_are_correct(
-            ACCESS_REVOKE_VALUE,
+            OS_GATEWAY_EVENT_TYPES.access_revoke,
             &access_revoke,
             Some(DEFAULT_GRANT_ID),
         );
         access_revoke = access_revoke.with_access_grant_id("grant_id_2");
         assert_attribute_values_are_correct(
-            ACCESS_REVOKE_VALUE,
+            OS_GATEWAY_EVENT_TYPES.access_revoke,
             &access_revoke,
             Some("grant_id_2"),
         );
@@ -206,10 +212,10 @@ mod tests {
         // verify that the output produced in the sorted result matches exactly with the sorted
         // key result.
         let mut expected_keys = vec![
-            SCOPE_ADDRESS_KEY,
-            ACCESS_GRANT_ID_KEY,
-            EVENT_TYPE_KEY,
-            TARGET_ACCOUNT_KEY,
+            OS_GATEWAY_KEYS.scope_address,
+            OS_GATEWAY_KEYS.access_grant_id,
+            OS_GATEWAY_KEYS.event_type,
+            OS_GATEWAY_KEYS.target_account,
         ];
         expected_keys.sort();
         for (index, key) in expected_keys.into_iter().enumerate() {
@@ -244,52 +250,52 @@ mod tests {
             "expected the correct number of attributes to be held in the cosmwasm response",
         );
         assert_eq!(
-            expected_event_key, generator.attributes[EVENT_TYPE_KEY],
+            expected_event_key, generator.attributes[OS_GATEWAY_KEYS.event_type],
             "the event type key should equate to the expected value in the attribute generator",
         );
         assert_eq!(
             expected_event_key,
-            single_attribute_for_key(&response, EVENT_TYPE_KEY),
+            single_attribute_for_key(&response, OS_GATEWAY_KEYS.event_type),
             "the event the key should equate to the expected value in the cosmwasm response",
         );
         assert_eq!(
-            DEFAULT_SCOPE_ADDRESS, generator.attributes[SCOPE_ADDRESS_KEY],
+            DEFAULT_SCOPE_ADDRESS, generator.attributes[OS_GATEWAY_KEYS.scope_address],
             "the scope address key should contain the default scope address value in the attribute generator",
         );
         assert_eq!(
             DEFAULT_SCOPE_ADDRESS,
-            single_attribute_for_key(&response, SCOPE_ADDRESS_KEY),
+            single_attribute_for_key(&response, OS_GATEWAY_KEYS.scope_address),
             "the scope address key should contain the default scope address value in the cosmwasm response",
         );
         assert_eq!(
-            DEFAULT_TARGET_ACCOUNT, generator.attributes[TARGET_ACCOUNT_KEY],
+            DEFAULT_TARGET_ACCOUNT, generator.attributes[OS_GATEWAY_KEYS.target_account],
             "the target account key should contain the default target account address value in the attribute generator",
         );
         assert_eq!(
             DEFAULT_TARGET_ACCOUNT,
-            single_attribute_for_key(&response, TARGET_ACCOUNT_KEY),
+            single_attribute_for_key(&response, OS_GATEWAY_KEYS.target_account),
             "the target account key should contain the default target account address value in the cosmwasm response",
         );
         if let Some(grant_id) = grant_id {
             assert_eq!(
-                grant_id, generator.attributes[ACCESS_GRANT_ID_KEY],
+                grant_id, generator.attributes[OS_GATEWAY_KEYS.access_grant_id],
                 "the access grant id key should contain the provided access grant id value in the attribute generator",
             );
             assert_eq!(
                 grant_id,
-                single_attribute_for_key(&response, ACCESS_GRANT_ID_KEY),
+                single_attribute_for_key(&response, OS_GATEWAY_KEYS.access_grant_id),
                 "the access grant id key should contain the provided access grant id value in the cosmwasm response",
             );
         } else {
             assert!(
-                !generator.attributes.contains_key(ACCESS_GRANT_ID_KEY),
+                !generator.attributes.contains_key(OS_GATEWAY_KEYS.access_grant_id),
                 "the access grant id key was not expected to be provided to the attribute generator",
             );
             assert!(
                 !response
                     .attributes
                     .iter()
-                    .any(|attr| attr.key == ACCESS_GRANT_ID_KEY),
+                    .any(|attr| attr.key == OS_GATEWAY_KEYS.access_grant_id),
                 "the access grant id key was not expected to be provided to the cosmwasm response",
             )
         }

--- a/src/attribute_keys.rs
+++ b/src/attribute_keys.rs
@@ -1,27 +1,31 @@
-/// Denotes to [Object Store Gateway](https://github.com/provenance-io/object-store-gateway) which
-/// functionality to invoke upon digesting this event.
 const EVENT_TYPE_KEY: &str = "object_store_gateway_event_type";
-
-/// Denotes to [Object Store Gateway](https://github.com/provenance-io/object-store-gateway) which
-/// [Provenance Blockchain Scope](https://docs.provenance.io/modules/metadata-module#scope-data-structures)
-/// this event refers to.
 const SCOPE_ADDRESS_KEY: &str = "object_store_gateway_scope_address";
-
-/// Denotes to [Object Store Gateway](https://github.com/provenance-io/object-store-gateway) which
-/// [Provenance Blockchain Account](https://docs.provenance.io/blockchain/basics/accounts) this
-/// event will take action upon.
 const TARGET_ACCOUNT_KEY: &str = "object_store_gateway_target_account_address";
-
-/// If provided, this key denotes to [Object Store Gateway](https://github.com/provenance-io/object-store-gateway)
-/// that the access grant being referred to should be linked with this ID.
-///
-/// * On a grant request: The resulting grant will be created with this ID, or rejected if a grant
-/// with this ID already exists.
-/// * On a revoke request: An existing grant with the specified scope and target account will be
-/// deleted if it exists.
 const ACCESS_GRANT_ID_KEY: &str = "object_store_gateway_access_grant_id";
 
 /// A simple struct to contain all gateway key constants.
+///
+/// # Parameters
+///
+/// * `event_type` Denotes to [Object Store Gateway](https://github.com/provenance-io/object-store-gateway)
+/// which functionality to invoke upon digesting this event.
+///
+/// * `scope_address` Denotes to [Object Store Gateway](https://github.com/provenance-io/object-store-gateway)
+/// which [Provenance Blockchain Scope](https://docs.provenance.io/modules/metadata-module#scope-data-structures)
+/// this event refers to.
+///
+/// * `target_account` Denotes to [Object Store Gateway](https://github.com/provenance-io/object-store-gateway)
+/// which [Provenance Blockchain Account](https://docs.provenance.io/blockchain/basics/accounts)
+/// this event will take action upon.
+///
+/// * `access_grant_id` If provided, this key denotes to [Object Store Gateway](https://github.com/provenance-io/object-store-gateway)
+/// that the access grant being referred to should be linked with this ID.
+///
+/// __On a grant request__: The resulting grant will be created with this ID, or rejected if a grant
+/// with this ID already exists.
+///
+/// __On a revoke request__: An existing grant with the specified scope and target account will be
+/// deleted if it exists.
 pub struct OsGatewayKeys<'a> {
     pub event_type: &'a str,
     pub scope_address: &'a str,
@@ -31,6 +35,28 @@ pub struct OsGatewayKeys<'a> {
 
 /// Contains all different attribute keys recognized by [Object Store Gateway](https://github.com/provenance-io/object-store-gateway)
 /// when interpreting events.
+///
+/// # Values
+///
+/// * `event_type` Denotes to [Object Store Gateway](https://github.com/provenance-io/object-store-gateway)
+/// which functionality to invoke upon digesting this event.
+///
+/// * `scope_address` Denotes to [Object Store Gateway](https://github.com/provenance-io/object-store-gateway)
+/// which [Provenance Blockchain Scope](https://docs.provenance.io/modules/metadata-module#scope-data-structures)
+/// this event refers to.
+///
+/// * `target_account` Denotes to [Object Store Gateway](https://github.com/provenance-io/object-store-gateway)
+/// which [Provenance Blockchain Account](https://docs.provenance.io/blockchain/basics/accounts)
+/// this event will take action upon.
+///
+/// * `access_grant_id` If provided, this key denotes to [Object Store Gateway](https://github.com/provenance-io/object-store-gateway)
+/// that the access grant being referred to should be linked with this ID.
+///
+/// __On a grant request__: The resulting grant will be created with this ID, or rejected if a grant
+/// with this ID already exists.
+///
+/// __On a revoke request__: An existing grant with the specified scope and target account will be
+/// deleted if it exists.
 pub const OS_GATEWAY_KEYS: OsGatewayKeys<'static> = OsGatewayKeys {
     event_type: EVENT_TYPE_KEY,
     scope_address: SCOPE_ADDRESS_KEY,

--- a/src/attribute_keys.rs
+++ b/src/attribute_keys.rs
@@ -1,16 +1,16 @@
 /// Denotes to [Object Store Gateway](https://github.com/provenance-io/object-store-gateway) which
 /// functionality to invoke upon digesting this event.
-pub const EVENT_TYPE_KEY: &str = "object_store_gateway_event_type";
+const EVENT_TYPE_KEY: &str = "object_store_gateway_event_type";
 
 /// Denotes to [Object Store Gateway](https://github.com/provenance-io/object-store-gateway) which
 /// [Provenance Blockchain Scope](https://docs.provenance.io/modules/metadata-module#scope-data-structures)
 /// this event refers to.
-pub const SCOPE_ADDRESS_KEY: &str = "object_store_gateway_scope_address";
+const SCOPE_ADDRESS_KEY: &str = "object_store_gateway_scope_address";
 
 /// Denotes to [Object Store Gateway](https://github.com/provenance-io/object-store-gateway) which
 /// [Provenance Blockchain Account](https://docs.provenance.io/blockchain/basics/accounts) this
 /// event will take action upon.
-pub const TARGET_ACCOUNT_KEY: &str = "object_store_gateway_target_account_address";
+const TARGET_ACCOUNT_KEY: &str = "object_store_gateway_target_account_address";
 
 /// If provided, this key denotes to [Object Store Gateway](https://github.com/provenance-io/object-store-gateway)
 /// that the access grant being referred to should be linked with this ID.
@@ -19,14 +19,21 @@ pub const TARGET_ACCOUNT_KEY: &str = "object_store_gateway_target_account_addres
 /// with this ID already exists.
 /// * On a revoke request: An existing grant with the specified scope and target account will be
 /// deleted if it exists.
-pub const ACCESS_GRANT_ID_KEY: &str = "object_store_gateway_access_grant_id";
+const ACCESS_GRANT_ID_KEY: &str = "object_store_gateway_access_grant_id";
 
-/// The expected value for the [Event Type Key](self::EVENT_TYPE_KEY) that denotes to
-/// [Object Store Gateway](https://github.com/provenance-io/object-store-gateway) that the event
-/// should be processed as an access grant.
-pub const ACCESS_GRANT_VALUE: &str = "access_grant";
+/// A simple struct to contain all gateway key constants.
+pub struct OsGatewayKeys<'a> {
+    pub event_type: &'a str,
+    pub scope_address: &'a str,
+    pub target_account: &'a str,
+    pub access_grant_id: &'a str,
+}
 
-/// The expected value for the [Event Type Key](self::EVENT_TYPE_KEY) that denotes to
-/// [Object Store Gateway](https://github.com/provenance-io/object-store-gateway) that the event
-/// should be processed as an access revocation.
-pub const ACCESS_REVOKE_VALUE: &str = "access_revoke";
+/// Contains all different attribute keys recognized by [Object Store Gateway](https://github.com/provenance-io/object-store-gateway)
+/// when interpreting events.
+pub const OS_GATEWAY_KEYS: OsGatewayKeys<'static> = OsGatewayKeys {
+    event_type: EVENT_TYPE_KEY,
+    scope_address: SCOPE_ADDRESS_KEY,
+    target_account: TARGET_ACCOUNT_KEY,
+    access_grant_id: ACCESS_GRANT_ID_KEY,
+};

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -40,10 +40,37 @@
 //!     }
 //!  }
 //! ```
+//!
+//! Also provided are the actual attribute keys used in the [OsGatewayAttributeGenerator](self::OsGatewayAttributeGenerator),
+//! as well as the different event types that are accepted by [Object Store Gateway](https://github.com/provenance-io/object-store-gateway).
+//!
+//! To use them, simply import and access their values from the provided const structs:
+//!
+//! ```
+//! mod some_mod {
+//!     use os_gateway_contract_attributes::{OS_GATEWAY_EVENT_TYPES, OS_GATEWAY_KEYS};
+//!     use std::println;
+//!
+//!     fn print_constants() {
+//!         // Print the keys
+//!         println!("Event type key: {}", OS_GATEWAY_KEYS.event_type);
+//!         println!("Scope address key: {}", OS_GATEWAY_KEYS.scope_address);
+//!         println!("Target account address key: {}", OS_GATEWAY_KEYS.target_account);
+//!         println!("Access grant id key: {}", OS_GATEWAY_KEYS.access_grant_id);
+//!         // Print the event types
+//!         println!("Access grant event type: {}", OS_GATEWAY_EVENT_TYPES.access_grant);
+//!         println!("Access revoke event type: {}", OS_GATEWAY_EVENT_TYPES.access_revoke);
+//!     }
+//! }
 
+pub use attribute_event_types::{OsGatewayEventTypes, OS_GATEWAY_EVENT_TYPES};
 pub use attribute_generator::OsGatewayAttributeGenerator;
+pub use attribute_keys::{OsGatewayKeys, OS_GATEWAY_KEYS};
 
-/// Internal attribute values that drive the event keys and values generated.
-mod attribute_consts;
+/// Attribute qualifiers that drive the values generated for the object_store_gateway_event_type
+/// attribute.
+mod attribute_event_types;
 /// A struct that generates attributes that can be consumed fluently by a cosmwasm Response.
 mod attribute_generator;
+/// Attribute qualifiers that drive the event keys that are generated.
+mod attribute_keys;


### PR DESCRIPTION
# Description
I realized when adding the placeholder values to asset classification that it might be worthwhile (even if just for testing) that the event attribute keys as well as the event types be exposed.

## Changes
- Move event types and keys to their own files, respectively: `attribute_event_types.rs` and `attribute_keys.rs`.
- Create const structs that contain the attributes for easy access in other repositories, versus having a bunch of free-floating constant values to guess at.
- Additional documentation on these exposed values.